### PR TITLE
test for .username before using it

### DIFF
--- a/kuma/javascript/src/accountsettings/pages/index.jsx
+++ b/kuma/javascript/src/accountsettings/pages/index.jsx
@@ -18,7 +18,6 @@ const pageSubtitle = gettext('Update your details and manage your preferences');
 export default function LandingPage({ data, locale }: RouteComponentProps) {
     const contributionSupportEmail = data.contributionSupportEmail;
     const userData = useContext(UserProvider.context);
-    const { username }: any = userData;
 
     return (
         <main id="content" role="main" data-testid="landing-page">
@@ -33,7 +32,7 @@ export default function LandingPage({ data, locale }: RouteComponentProps) {
                 </p>
             )}
 
-            {userData && userData.isAuthenticated && (
+            {userData && userData.isAuthenticated && userData.username && (
                 <>
                     <Titlebar
                         pageTitle={pageTitle}
@@ -50,7 +49,10 @@ export default function LandingPage({ data, locale }: RouteComponentProps) {
                         userData={userData}
                         contributionSupportEmail={contributionSupportEmail}
                     />
-                    <CloseAccount locale={locale} username={username} />
+                    <CloseAccount
+                        locale={locale}
+                        username={userData.username}
+                    />
                 </>
             )}
         </main>

--- a/kuma/javascript/src/accountsettings/pages/index.test.jsx
+++ b/kuma/javascript/src/accountsettings/pages/index.test.jsx
@@ -33,6 +33,7 @@ describe('Account Settings Landing Page', () => {
     it('renders the account settings form for authenticated users', () => {
         const mockData = getTestData({
             isAuthenticated: true,
+            username: 'something',
         });
 
         render(
@@ -48,6 +49,7 @@ describe('Account Settings Landing Page', () => {
     it('renders the subscription component for authenticated users', () => {
         const mockData = getTestData({
             isAuthenticated: true,
+            username: 'something',
         });
 
         render(
@@ -64,6 +66,7 @@ describe('Account Settings Landing Page', () => {
     it('renders the close account component for authenticated users', () => {
         const mockData = getTestData({
             isAuthenticated: true,
+            username: 'something',
         });
 
         render(


### PR DESCRIPTION
It's actually an interesting problem. It's a fundamental one actually. 
You know. And I know. That if a user is `isAuthenticated` it does always mean that `username` is truthy and a string. But Flow doesn't and can't know that. But by doing an if before user `userData.username` Flow can deduce that it's always something. 

I think we should take a look at how we're doing this with TS in Yari and see if we can perfect it there. 